### PR TITLE
[BUGFIX] Fix return value

### DIFF
--- a/src/Translation.php
+++ b/src/Translation.php
@@ -10,7 +10,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 trait Translation
 {
-    public function getLabel(): string
+    public function getLabel(): mixed
     {
         $translationString = $this->getTranslationString();
         $label = self::getTranslationService()->sL($translationString);


### PR DESCRIPTION
The return value of a backed enum could be any primitive data type